### PR TITLE
Add RCSotController destructor

### DIFF
--- a/src/roscontrol-sot-controller.hh
+++ b/src/roscontrol-sot-controller.hh
@@ -159,6 +159,8 @@ private:
 public:
   RCSotController();
 
+  virtual ~RCSotController();
+
   /// \brief Read the configuration files,
   /// claims the request to the robot and initialize the Stack-Of-Tasks.
   bool initRequest(lhi::RobotHW *robot_hw, ros::NodeHandle &robot_nh,


### PR DESCRIPTION
Move cleanup and log destruction to destructor in order to enable
stopping/starting with ROS controller manager