### PR TITLE
[RCSotController] Save log in destructor

### DIFF
--- a/src/roscontrol-sot-controller.cpp
+++ b/src/roscontrol-sot-controller.cpp
@@ -78,6 +78,11 @@ RCSotController::RCSotController()
 }
 
 RCSotController::~RCSotController() {
+  std::string afilename("/tmp/sot.log");
+
+  RcSotLog_.record(DataOneIter_);
+  RcSotLog_.save(afilename);
+
   SotLoaderBasic::CleanUp();
   using namespace ::dynamicgraph;
   RealTimeLogger::destroy();
@@ -1125,11 +1130,6 @@ void RCSotController::starting(const ros::Time &) {
 }
 
 void RCSotController::stopping(const ros::Time &) {
-  std::string afilename("/tmp/sot.log");
-
-  RcSotLog_.record(DataOneIter_);
-  RcSotLog_.save(afilename);
-
 }
 
 PLUGINLIB_EXPORT_CLASS(sot_controller::RCSotController, lci::ControllerBase)


### PR DESCRIPTION
  instead of in method stopping.
  The ROS driver for UniversalRobot stops from time to time.
  When this happens, roscontrol process is stopped and restarted.
  Before this commit, saving the logs between stop and restart
  made the robot stop for a few seconds. This is undesirable.

This is a continuation of https://github.com/stack-of-tasks/roscontrol_sot/pull/31.