### PR TITLE
[RSSotController] Fix subsampling machinery after testing on UR10.

### DIFF
--- a/src/roscontrol-sot-controller.cpp
+++ b/src/roscontrol-sot-controller.cpp
@@ -945,8 +945,8 @@ void RCSotController::readControl(
 
   } else {
     ROS_INFO_STREAM("no control.");
-    localStandbyEffortControlMode(ros::Duration(dt_/subSampling_));
-    localStandbyVelocityControlMode(ros::Duration(dt_/subSampling_));
+    localStandbyEffortControlMode(ros::Duration(dt_ / subSampling_));
+    localStandbyVelocityControlMode(ros::Duration(dt_ / subSampling_));
     localStandbyPositionControlMode();
   }
 }
@@ -982,7 +982,7 @@ void RCSotController::one_iteration() {
 
   // Wait until last subsampling step to write result in controlValues_
   while (step_ != subSampling_ - 1) {
-    ros::Duration(.01 * dt_/subSampling_).sleep();
+    ros::Duration(.01 * dt_ / subSampling_).sleep();
   }
   // mutex
   mutex_.lock();
@@ -1087,7 +1087,7 @@ void RCSotController::localStandbyPositionControlMode() {
 }
 
 void RCSotController::computeSubSampling() {
-  if ((subSampling_ != 1) && !thread_created_){
+  if ((subSampling_ != 1) && !thread_created_) {
     step_ = subSampling_ - 1;
     ROS_INFO_STREAM("Subsampling SoT graph computation by ratio "
                     << subSampling_);

--- a/src/roscontrol-sot-controller.hh
+++ b/src/roscontrol-sot-controller.hh
@@ -78,7 +78,7 @@ class RCSotController : public lci::ControllerBase, SotLoaderBasic {
   rc_sot_system::DataToLog DataOneIter_;
 
  private:
-  void computeSubSampling(const ros::Duration &period);
+  void computeSubSampling();
   /// @{ \name Ros-control related fields
 
   /// \brief Vector of joint handles.
@@ -146,11 +146,9 @@ class RCSotController : public lci::ControllerBase, SotLoaderBasic {
   std::map<std::string, std::string> mapFromRCToSotDevice_;
 
   /// ratio between sot control period and roscontrol control period
-  std::size_t subSampling_;
+  int subSampling_;
   /// iteration index of the subsampling. Ranges from 0 to subSampling_-1
-  std::atomic<std::size_t> step_;
-  /// double roscontrol sampling period
-  double dtRos_;
+  std::atomic<int> step_;
   /// \brief Verbosity level for ROS messages during initRequest/initialization
   /// phase. 0: no messages or error 1: info 2: debug
   int verbosity_level_;
@@ -165,6 +163,7 @@ class RCSotController : public lci::ControllerBase, SotLoaderBasic {
   boost::asio::io_service io_service_;
   boost::asio::io_service::work io_work_;
   boost::thread_group thread_pool_;
+  bool thread_created_;
   // mutex to protect access to controlValues_
   std::mutex mutex_;
   // Flag informing whether the graph computation is running to avoid starting


### PR DESCRIPTION
Fix subsampling after testing on UR10. The main issue was that the ros::duration argument passed to update is not the theoretical time period, thus the computation of the subsampling rate threw an exception.

Moreover, we forgot to call method readControl when no subsampling was done.