### PR TITLE
[log] Set duration to 0 when next time stamp is smaller

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -223,7 +223,8 @@ void Log::saveVector(std::string &fileName, std::string &suffix,
         dt = StoredData_.timestamp[0] -
              StoredData_.timestamp[profileLog_.length - 1];
       } else
-        dt = StoredData_.timestamp[k] - StoredData_.timestamp[k - 1];
+        dt = std::max(0., StoredData_.timestamp[k] -
+                      StoredData_.timestamp[k - 1]);
       writeToBinaryFile(aof, StoredData_.timestamp[i], dt, avector, idx, size);
       idx = (idx + size) % N;
     }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -223,8 +223,8 @@ void Log::saveVector(std::string &fileName, std::string &suffix,
         dt = StoredData_.timestamp[0] -
              StoredData_.timestamp[profileLog_.length - 1];
       } else
-        dt = std::max(0., StoredData_.timestamp[k] -
-                      StoredData_.timestamp[k - 1]);
+        dt = std::max(0.,
+                      StoredData_.timestamp[k] - StoredData_.timestamp[k - 1]);
       writeToBinaryFile(aof, StoredData_.timestamp[i], dt, avector, idx, size);
       idx = (idx + size) % N;
     }


### PR DESCRIPTION
  Due to the circular buffer, when overwriting previously logged data,
  the iteration duration could be highly negative. Set it to zero in that case.